### PR TITLE
Add constant for activity type

### DIFF
--- a/ARSafariActivity/ARSafariActivity.h
+++ b/ARSafariActivity/ARSafariActivity.h
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+extern NSString * const ARSafariActivityType;
+
 @interface ARSafariActivity : UIActivity
 
 @property (nonatomic, strong) NSURL *url;

--- a/ARSafariActivity/ARSafariActivity.m
+++ b/ARSafariActivity/ARSafariActivity.m
@@ -14,11 +14,13 @@
 
 #import "ARSafariActivity.h"
 
+NSString * const ARSafariActivityType = @"ARSafariActivity";
+
 @implementation ARSafariActivity
 
 - (NSString *)activityType
 {
-	return NSStringFromClass([self class]);
+	return ARSafariActivityType;
 }
 
 - (UIImage *)activityImage


### PR DESCRIPTION
Change the `-activityType` to use a constant instead of just using the class name at runtime.
##### Background:

In my project, I've implemented `UIActivityItemSource` to selectively add activity items for various sharing types. I've made this change so I don't have to create a new `ARSafariActivity` instance every time I want to get the activity type for this filtering.
